### PR TITLE
Use json for subordinate configuration.

### DIFF
--- a/provides.py
+++ b/provides.py
@@ -50,4 +50,4 @@ class CinderBackendProvides(RelationBase):
         }
         conv.set_remote(backend_name=backend_name,
                         stateless=stateless,
-                        subordinate_configuration=configuration)
+                        subordinate_configuration=json.dumps(configuration))


### PR DESCRIPTION
JSON encoding the subordinate config data is the preffered way to
pass it down the relation. This is supported by the corresponding
context https://github.com/juju/charm-helpers/blob/master/charmhelpers/contrib/openstack/context.py#L1272
and this is the approach cinder-ceph takes.